### PR TITLE
Fix NaN bug in split_book and split_chapter for Nahjul Balaghah

### DIFF
--- a/src/deen_scraper/cleaners/base.py
+++ b/src/deen_scraper/cleaners/base.py
@@ -77,12 +77,16 @@ def extract_topic_tags(chapter_title: str) -> list[str]:
 
 def split_book(book: str) -> tuple[str, str]:
     """Split a ``"number | Title"`` book field into (book_number, book_title)."""
+    if not book or str(book).strip().lower() in ("nan", "none", ""):
+        return "", ""
     parts = str(book).split("|")
     return parts[0].strip(), parts[1].strip() if len(parts) > 1 else parts[0].strip()
 
 
 def split_chapter(chapter: str) -> tuple[str, str]:
     """Split a ``"number | Title"`` chapter field into (chapter_number, chapter_title)."""
+    if not chapter or str(chapter).strip().lower() in ("nan", "none", ""):
+        return "", ""
     parts = str(chapter).split("|", 1)
     return parts[0].strip(), parts[1].strip() if len(parts) > 1 else ""
 


### PR DESCRIPTION
split_book and split_chapter were not handling NaN from the CSV. Added a guard clause to return empty strings when the input is NaN. 

Issue : DEE-22 